### PR TITLE
Fix prepending extra slash breaking redirects

### DIFF
--- a/src/services/MisdirectionService.php
+++ b/src/services/MisdirectionService.php
@@ -330,16 +330,16 @@ class MisdirectionService
                     // Bypass the request filter.
 
                     case 'Nearest':
-                        $link = '/' . HTTP::setGetVar('misdirected', true, $nearestParent);
+                        $link = HTTP::setGetVar('misdirected', true, $nearestParent);
                         break;
                     case 'This':
-                        $link = '/' . HTTP::setGetVar('misdirected', true, $thisPage);
+                        $link = HTTP::setGetVar('misdirected', true, $thisPage);
                         break;
                     case 'URL':
 
                         // When appropriate, prepend the base URL to match a page redirection.
 
-                        $link = self::is_external_URL($toURL) ? (ClassInfo::exists(Multisites::class) ? HTTP::setGetVar('misdirected', true, $toURL) : $toURL) : ('/' . HTTP::setGetVar('misdirected', true, Controller::join_links(Director::baseURL(), $toURL)));
+                        $link = self::is_external_URL($toURL) ? (ClassInfo::exists(Multisites::class) ? HTTP::setGetVar('misdirected', true, $toURL) : $toURL) : (HTTP::setGetVar('misdirected', true, Controller::join_links(Director::baseURL(), $toURL)));
                         break;
                 }
                 if ($link) {


### PR DESCRIPTION
With the "Nearest parent" option, this was redirecting to invalid URLs such as `//?misdirected=1`

As far as I can see `HTTP::setGetVar` will always return an absolute URL, so prepending a slash doesn't make sense.

Can we also get a version tagged some time?