### PR TITLE
Add DB indexes to LinkMapping

### DIFF
--- a/src/objects/LinkMapping.php
+++ b/src/objects/LinkMapping.php
@@ -45,6 +45,20 @@ class LinkMapping extends DataObject {
 		'HostnameRestriction' => 'Varchar(255)'
 	);
 
+    /**
+     * @inheritdoc
+     */
+    private static $indexes = [
+        'LinkType' => true,
+        'MappedLink' => true,
+        'IncludesHostname' => true,
+        'Priority' => true,
+        'RedirectType' => true,
+        'RedirectLink' => true,
+        'RedirectPageID' => true,
+        'HostnameRestriction' => true
+    ];
+
 	private static $defaults = array(
 		'ResponseCode' => 301
 	);


### PR DESCRIPTION
This change add indexes to commonly used LinkMapping fields appearing in queries.
This improves query performance and avoids full table scans, especially when a lot of LinkMapping records are present.

The indexes added represent fields used to find a LinkMapping record in MisdirectionService::getMapping();

Example with index on RedirectType with 1000 records and the query as below:

```sql
EXPLAIN SELECT DISTINCT `LinkMapping`.`ClassName`, `LinkMapping`.`LastEdited`, `LinkMapping`.`Created`, `LinkMapping`.`LinkType`, `LinkMappingLinkMapping`.`RedirectLink`, `LinkMapping`.`RedirectPageID`, `LinkMapping`.`ResponseCode`, `LinkMapping`.`HostnameRestriction`, `LinkMapping`.`ID`,                      ELSE 'nglasl\\misdirection\\LinkMapping' END AS `RecordClassName` 
FROM `LinkMapping`  
WHERE (`LinkMapping`.`MappedLink` LIKE '%11%') 
ORDER BY `LinkMapping`.`RedirectType` ASC
LIMIT 10;
```

Result with index on RedirectType and MappedLink (type=index)

```
+----+-------------+-------------+------------+-------+---------------+--------------+---------+------+------+----------+-------------+
| id | select_type | table       | partitions | type  | possible_keys | key          | key_len | ref  | rows | filtered | Extra       |
+----+-------------+-------------+------------+-------+---------------+--------------+---------+------+------+----------+-------------+
|  1 | SIMPLE      | LinkMapping | NULL       | index | NULL          | RedirectType | 2       | NULL |   10 |    11.11 | Using where |
+----+-------------+-------------+------------+-------+---------------+--------------+---------+------+------+----------+-------------+
```

Without the indexes, same query (type=ALL)
```
+----+-------------+-------------+------------+------+---------------+------+---------+------+------+----------+-----------------------------+
| id | select_type | table       | partitions | type | possible_keys | key  | key_len | ref  | rows | filtered | Extra                       |
+----+-------------+-------------+------------+------+---------------+------+---------+------+------+----------+-----------------------------+
|  1 | SIMPLE      | LinkMapping | NULL       | ALL  | NULL          | NULL | NULL    | NULL | 1000 |    11.11 | Using where; Using filesort |
+----+-------------+-------------+------------+------+---------------+------+---------+------+------+----------+-----------------------------+
```
