### PR TITLE
Cleanup with php-cs-fixer

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,20 @@
+[*]
+charset = utf-8
+end_of_line = lf
+indent_size = 4
+indent_style = space
+insert_final_newline = true
+trim_trailing_whitespace = true
+
+[*.md]
+trim_trailing_whitespace = false
+
+[*.{yml,js,json,css,scss,eslintrc,feature}]
+indent_size = 2
+indent_style = space
+
+[package.json]
+indent_size = 2
+
+[composer.json]
+indent_size = 4

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,8 @@
+/tests                      export-ignore
+/docs                       export-ignore
+/.editorconfig              export-ignore
+/.gitattributes             export-ignore
+/.gitignore                 export-ignore
+/.php-cs-fixer.dist.php     export-ignore
+/CONTRIBUTING.md            export-ignore
+/README.md                  export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+/.php-cs-fixer.cache

--- a/.php-cs-fixer.dist.php
+++ b/.php-cs-fixer.dist.php
@@ -1,0 +1,21 @@
+<?php
+/**
+ * Configuration file for https://github.com/FriendsOfPHP/PHP-CS-Fixer
+ * Install with composer: $ composer global require friendsofphp/php-cs-fixer
+ * Usage (in this directory) :  ~/.composer/vendor/bin/php-cs-fixer fix .
+ */
+$finder = PhpCsFixer\Finder::create()
+            ->in(__DIR__);
+
+$config = new PhpCsFixer\Config();
+return $config->setRules([
+            '@PSR2' => true,
+            'array_indentation' => true,
+            'array_syntax' => ['syntax' => 'short'],
+            'blank_line_after_namespace' => true,
+            'blank_line_after_opening_tag' => true,
+            'full_opening_tag' => true,
+            'no_closing_tag' => true,
+        ])
+        ->setIndent("    ")
+        ->setFinder($finder);

--- a/composer.json
+++ b/composer.json
@@ -22,6 +22,10 @@
 	"require": {
 		"silverstripe/framework": "~4.0"
 	},
+    "require-dev": {
+        "phpunit/phpunit": "^9.5",
+        "friendsofphp/php-cs-fixer": "^3"
+    },
 	"autoload": {
 		"psr-4": {
 			"nglasl\\misdirection\\": [

--- a/src/controllers/MisdirectionAdmin.php
+++ b/src/controllers/MisdirectionAdmin.php
@@ -13,70 +13,70 @@ use SilverStripe\Security\Permission;
  */
 class MisdirectionAdmin extends ModelAdmin
 {
-	private static $managed_models = LinkMapping::class;
+    private static $managed_models = LinkMapping::class;
 
-	private static $menu_title = 'Misdirection';
+    private static $menu_title = 'Misdirection';
 
-	private static $menu_description = 'Create, manage and test customisable link redirection mappings.';
+    private static $menu_description = 'Create, manage and test customisable link redirection mappings.';
 
-	private static $menu_icon_class = 'font-icon-switch';
+    private static $menu_icon_class = 'font-icon-switch';
 
-	private static $url_segment = 'misdirection';
+    private static $url_segment = 'misdirection';
 
-	private static $allowed_actions = array(
-		'getMappingChain'
-	);
+    private static $allowed_actions = [
+        'getMappingChain'
+    ];
 
-	/**
-	 *	Update the custom summary fields to be sortable.
-	 */
-	public function getEditForm($ID = null, $fields = null) {
+    /**
+     *	Update the custom summary fields to be sortable.
+     */
+    public function getEditForm($ID = null, $fields = null)
+    {
 
-		$form = parent::getEditForm($ID, $fields);
-		$gridfield = $form->Fields()->fieldByName($this->sanitiseClassName($this->modelClass));
-		$gridfield->getConfig()->getComponentByType(GridFieldSortableHeader::class)->setFieldSorting(array(
-			'RedirectTypeSummary' => 'RedirectType'
-		));
+        $form = parent::getEditForm($ID, $fields);
+        $gridfield = $form->Fields()->fieldByName($this->sanitiseClassName($this->modelClass));
+        $gridfield->getConfig()->getComponentByType(GridFieldSortableHeader::class)->setFieldSorting([
+            'RedirectTypeSummary' => 'RedirectType'
+        ]);
 
-		// Allow extension customisation.
+        // Allow extension customisation.
 
-		$this->extend('updateMisdirectionAdminEditForm', $form);
-		return $form;
-	}
+        $this->extend('updateMisdirectionAdminEditForm', $form);
+        return $form;
+    }
 
-	/**
-	 *	Retrieve the JSON link mapping recursion stack for the testing interface.
-	 *
-	 *	@URLparameter map <{TEST_URL}> string
-	 *	@return JSON
-	 */
-	public function getMappingChain()
-	{
-		$user = Member::currentUserID();
+    /**
+     *	Retrieve the JSON link mapping recursion stack for the testing interface.
+     *
+     *	@URLparameter map <{TEST_URL}> string
+     *	@return JSON
+     */
+    public function getMappingChain()
+    {
+        $user = Member::currentUserID();
 
-		if (singleton(LinkMapping::class)->canCreate()) {
+        if (singleton(LinkMapping::class)->canCreate()) {
 
-			// Instantiate a request to handle the link mapping.
-			$request = new HTTPRequest('GET', $this->getRequest()->getVar('map'));
+            // Instantiate a request to handle the link mapping.
+            $request = new HTTPRequest('GET', $this->getRequest()->getVar('map'));
 
-			// Retrieve the link mapping recursion stack JSON.
-			$testing = true;
-			$mappings = singleton(MisdirectionService::class)->getMappingByRequest($request, $testing);
+            // Retrieve the link mapping recursion stack JSON.
+            $testing = true;
+            $mappings = singleton(MisdirectionService::class)->getMappingByRequest($request, $testing);
 
-			$this->getResponse()->addHeader('Content-Type', 'application/json');
+            $this->getResponse()->addHeader('Content-Type', 'application/json');
 
-			// JSON_PRETTY_PRINT.
-			return json_encode($mappings, 128);
-		}
-		else {
-			return $this->httpError(404);
-		}
-	}
+            // JSON_PRETTY_PRINT.
+            return json_encode($mappings, 128);
+        } else {
+            return $this->httpError(404);
+        }
+    }
 
-	/**
+    /**
      * Export all domain model fields, instead of display fields to allow for
-	 * importing the list again
-	 *
+     * importing the list again
+     *
      * @return array
      */
     public function getExportFields()
@@ -93,7 +93,7 @@ class MisdirectionAdmin extends ModelAdmin
         $fields['ForwardPOSTRequest'] = 'ForwardPOSTRequest';
         $fields['HostnameRestriction'] = 'HostnameRestriction';
 
-		$this->extend('updateExportFields', $fields);
+        $this->extend('updateExportFields', $fields);
 
         return $fields;
     }

--- a/src/extensions/MisdirectionAdminTestingExtension.php
+++ b/src/extensions/MisdirectionAdminTestingExtension.php
@@ -12,34 +12,36 @@ use SilverStripe\View\Requirements;
  *	@author Nathan Glasl <nathan@symbiote.com.au>
  */
 
-class MisdirectionAdminTestingExtension extends Extension {
+class MisdirectionAdminTestingExtension extends Extension
+{
 
-	/**
-	 *	Update the edit form to include the URL input and test button.
-	 */
+    /**
+     *	Update the edit form to include the URL input and test button.
+     */
 
-	public function updateEditForm($form) {
+    public function updateEditForm($form)
+    {
 
-		Requirements::css('nglasl/silverstripe-misdirection: client/css/misdirection.css');
+        Requirements::css('nglasl/silverstripe-misdirection: client/css/misdirection.css');
 
-		// Restrict this functionality to administrators.
+        // Restrict this functionality to administrators.
 
-		$user = Member::currentUserID();
-		if(Permission::checkMember($user, 'ADMIN')) {
-			$gridfield = $form->fields->items[0];
-			if(isset($gridfield)) {
+        $user = Member::currentUserID();
+        if(Permission::checkMember($user, 'ADMIN')) {
+            $gridfield = $form->fields->items[0];
+            if(isset($gridfield)) {
 
-				// Add the required HTML fragment.
+                // Add the required HTML fragment.
 
-				Requirements::javascript('nglasl/silverstripe-misdirection: client/javascript/misdirection-testing.js');
-				$configuration = $gridfield->config;
-				$configuration->addComponent(new MisdirectionTesting());
-			}
-		}
+                Requirements::javascript('nglasl/silverstripe-misdirection: client/javascript/misdirection-testing.js');
+                $configuration = $gridfield->config;
+                $configuration->addComponent(new MisdirectionTesting());
+            }
+        }
 
-		// Allow extension customisation.
+        // Allow extension customisation.
 
-		$this->owner->extend('updateMisdirectionAdminTestingExtensionEditForm', $form);
-	}
+        $this->owner->extend('updateMisdirectionAdminTestingExtensionEditForm', $form);
+    }
 
 }

--- a/src/extensions/MisdirectionFallbackExtension.php
+++ b/src/extensions/MisdirectionFallbackExtension.php
@@ -16,90 +16,94 @@ use SilverStripe\View\Requirements;
  *	@author Nathan Glasl <nathan@symbiote.com.au>
  */
 
-class MisdirectionFallbackExtension extends DataExtension {
+class MisdirectionFallbackExtension extends DataExtension
+{
 
-	private static $db = array(
-		'Fallback' => 'Varchar(255)',
-		'FallbackLink' => 'Varchar(255)',
-		'FallbackResponseCode' => 'Int'
-	);
+    private static $db = [
+        'Fallback' => 'Varchar(255)',
+        'FallbackLink' => 'Varchar(255)',
+        'FallbackResponseCode' => 'Int'
+    ];
 
-	private static $defaults = array(
-		'FallbackResponseCode' => 303
-	);
+    private static $defaults = [
+        'FallbackResponseCode' => 303
+    ];
 
-	/**
-	 *	Display the appropriate fallback fields.
-	 */
+    /**
+     *	Display the appropriate fallback fields.
+     */
 
-	public function updateCMSFields(FieldList $fields) {
+    public function updateCMSFields(FieldList $fields)
+    {
 
-		if($this->owner instanceof SiteConfig) {
-			return $this->owner->updateFields($fields);
-		}
-	}
+        if($this->owner instanceof SiteConfig) {
+            return $this->owner->updateFields($fields);
+        }
+    }
 
-	public function updateSettingsFields($fields) {
+    public function updateSettingsFields($fields)
+    {
 
-		// This extension only exists for pages.
+        // This extension only exists for pages.
 
-		return $this->owner->updateFields($fields);
-	}
+        return $this->owner->updateFields($fields);
+    }
 
-	public function updateFields($fields) {
+    public function updateFields($fields)
+    {
 
-		Requirements::javascript('nglasl/silverstripe-misdirection: client/javascript/misdirection-fallback.js');
+        Requirements::javascript('nglasl/silverstripe-misdirection: client/javascript/misdirection-fallback.js');
 
-		// Update any fields that are displayed when not viewing a page.
+        // Update any fields that are displayed when not viewing a page.
 
-		$tab = 'Root.Misdirection';
-		$options = array(
-			'Nearest' => 'Nearest Parent',
-			'This' => 'This Page',
-			'URL' => 'URL'
-		);
-		if($this->owner instanceof SiteConfig) {
-			$tab = 'Root.Pages';
-			unset($options['This']);
-		}
+        $tab = 'Root.Misdirection';
+        $options = [
+            'Nearest' => 'Nearest Parent',
+            'This' => 'This Page',
+            'URL' => 'URL'
+        ];
+        if($this->owner instanceof SiteConfig) {
+            $tab = 'Root.Pages';
+            unset($options['This']);
+        }
 
-		// Retrieve the fallback mapping selection.
+        // Retrieve the fallback mapping selection.
 
-		$fields->addFieldToTab($tab, HeaderField::create(
-			'FallbackHeader',
-			'Fallback'
-		));
-		$fields->addFieldToTab($tab, DropdownField::create(
-			'Fallback',
-			'To',
-			$options
-		)->addExtraClass('fallback')->setHasEmptyDefault(true)->setDescription('This will be used when children result in a <strong>page not found</strong>'));
-		$fields->addFieldToTab($tab, TextField::create(
-			'FallbackLink',
-			'URL'
-		)->addExtraClass('fallback-link')->setDescription('This requires the <strong>HTTP/S</strong> scheme for an external URL'));
+        $fields->addFieldToTab($tab, HeaderField::create(
+            'FallbackHeader',
+            'Fallback'
+        ));
+        $fields->addFieldToTab($tab, DropdownField::create(
+            'Fallback',
+            'To',
+            $options
+        )->addExtraClass('fallback')->setHasEmptyDefault(true)->setDescription('This will be used when children result in a <strong>page not found</strong>'));
+        $fields->addFieldToTab($tab, TextField::create(
+            'FallbackLink',
+            'URL'
+        )->addExtraClass('fallback-link')->setDescription('This requires the <strong>HTTP/S</strong> scheme for an external URL'));
 
-		// Retrieve the response code selection.
+        // Retrieve the response code selection.
 
-		$responses = Config::inst()->get(MisDirectionRequestProcessor::class, 'status_codes');
-		$selection = array();
-		foreach($responses as $code => $description) {
-			if(($code >= 300) && ($code < 400)) {
-				$selection[$code] = "{$code}: {$description}";
-			}
-		}
-		if(!$this->owner->FallbackResponseCode) {
-			$this->owner->FallbackResponseCode = 303;
-		}
-		$fields->addFieldToTab($tab, DropdownField::create(
-			'FallbackResponseCode',
-			'Response Code',
-			$selection
-		)->addExtraClass('fallback-response-code'));
+        $responses = Config::inst()->get(MisDirectionRequestProcessor::class, 'status_codes');
+        $selection = [];
+        foreach($responses as $code => $description) {
+            if(($code >= 300) && ($code < 400)) {
+                $selection[$code] = "{$code}: {$description}";
+            }
+        }
+        if(!$this->owner->FallbackResponseCode) {
+            $this->owner->FallbackResponseCode = 303;
+        }
+        $fields->addFieldToTab($tab, DropdownField::create(
+            'FallbackResponseCode',
+            'Response Code',
+            $selection
+        )->addExtraClass('fallback-response-code'));
 
-		// Allow extension customisation.
+        // Allow extension customisation.
 
-		$this->owner->extend('updateMisdirectionFallbackExtensionFields', $fields);
-	}
+        $this->owner->extend('updateMisdirectionFallbackExtensionFields', $fields);
+    }
 
 }

--- a/src/extensions/SiteTreeMisdirectionExtension.php
+++ b/src/extensions/SiteTreeMisdirectionExtension.php
@@ -17,233 +17,241 @@ use SilverStripe\ORM\ValidationResult;
  *	@author Nathan Glasl <nathan@symbiote.com.au>
  */
 
-class SiteTreeMisdirectionExtension extends DataExtension {
+class SiteTreeMisdirectionExtension extends DataExtension
+{
 
-	/**
-	 *	This provides link mapping customisation directly from a page.
-	 */
+    /**
+     *	This provides link mapping customisation directly from a page.
+     */
 
-	private static $has_one = array(
-		'VanityMapping' => LinkMapping::class
-	);
+    private static $has_one = [
+        'VanityMapping' => LinkMapping::class
+    ];
 
-	public function updateSettingsFields($fields) {
+    public function updateSettingsFields($fields)
+    {
 
-		$fields->addFieldToTab('Root.Misdirection', HeaderField::create(
-			'VanityHeader',
-			'Vanity'
-		));
-		if($this->owner->VanityMapping()->RedirectPageID != $this->owner->ID) {
+        $fields->addFieldToTab('Root.Misdirection', HeaderField::create(
+            'VanityHeader',
+            'Vanity'
+        ));
+        if($this->owner->VanityMapping()->RedirectPageID != $this->owner->ID) {
 
-			// The mapping may have been pointed to another page.
+            // The mapping may have been pointed to another page.
 
-			$this->owner->VanityMappingID = 0;
-		}
-		$fields->addFieldToTab('Root.Misdirection', TextField::create(
-			'VanityURL',
-			'URL',
-			$this->owner->VanityMapping()->MappedLink
-		)->setDescription('Mappings with higher priority will take precedence over this'));
+            $this->owner->VanityMappingID = 0;
+        }
+        $fields->addFieldToTab('Root.Misdirection', TextField::create(
+            'VanityURL',
+            'URL',
+            $this->owner->VanityMapping()->MappedLink
+        )->setDescription('Mappings with higher priority will take precedence over this'));
 
-		// Allow extension customisation.
+        // Allow extension customisation.
 
-		$this->owner->extend('updateSiteTreeMisdirectionExtensionSettingsFields', $fields);
-	}
+        $this->owner->extend('updateSiteTreeMisdirectionExtensionSettingsFields', $fields);
+    }
 
-	public function validate(ValidationResult $result) {
+    public function validate(ValidationResult $result)
+    {
 
-		// Retrieve the vanity mapping URL, where this is only possible using the POST variable.
+        // Retrieve the vanity mapping URL, where this is only possible using the POST variable.
 
-		$vanityURL = (!Controller::has_curr() || is_null($controller = Controller::curr()) || is_null($URL = $controller->getRequest()->postVar('VanityURL'))) ? $this->owner->VanityMapping()->MappedLink : $URL;
-		if(!$vanityURL) {
-			return $result;
-		}
+        $vanityURL = (!Controller::has_curr() || is_null($controller = Controller::curr()) || is_null($URL = $controller->getRequest()->postVar('VanityURL'))) ? $this->owner->VanityMapping()->MappedLink : $URL;
+        if(!$vanityURL) {
+            return $result;
+        }
 
-		// Determine whether another vanity mapping already exists.
-		
-		$existing = LinkMapping::get()->filter(array(
-			'MappedLink' => $vanityURL,
-			'RedirectType' => 'Page',
-			'RedirectPageID:not' => array(
-				0,
-				$this->owner->ID
-			)
-		))->first();
-		if($result->isValid() && $existing && ($page = $existing->getRedirectPage())) {
-			$link = Controller::join_links(CMSPageSettingsController::singleton()->Link('show'), $page->ID);
-			$result->addError("Vanity URL <a href='{$link}' target='_blank'>already exists</a>!", ValidationResult::TYPE_ERROR, null, ValidationResult::CAST_HTML);
-		}
+        // Determine whether another vanity mapping already exists.
+        
+        $existing = LinkMapping::get()->filter([
+            'MappedLink' => $vanityURL,
+            'RedirectType' => 'Page',
+            'RedirectPageID:not' => [
+                0,
+                $this->owner->ID
+            ]
+        ])->first();
+        if($result->isValid() && $existing && ($page = $existing->getRedirectPage())) {
+            $link = Controller::join_links(CMSPageSettingsController::singleton()->Link('show'), $page->ID);
+            $result->addError("Vanity URL <a href='{$link}' target='_blank'>already exists</a>!", ValidationResult::TYPE_ERROR, null, ValidationResult::CAST_HTML);
+        }
 
-		// Allow extension.
+        // Allow extension.
 
-		$this->owner->extend('validateSiteTreeMisdirectionExtension', $result);
-		return $result;
-	}
+        $this->owner->extend('validateSiteTreeMisdirectionExtension', $result);
+        return $result;
+    }
 
-	/**
-	 *	Update the corresponding vanity mapping.
-	 */
+    /**
+     *	Update the corresponding vanity mapping.
+     */
 
-	public function onBeforeWrite() {
+    public function onBeforeWrite()
+    {
 
-		parent::onBeforeWrite();
+        parent::onBeforeWrite();
 
-		// Retrieve the vanity mapping URL, where this is only possible using the POST variable.
+        // Retrieve the vanity mapping URL, where this is only possible using the POST variable.
 
-		$vanityURL = (!Controller::has_curr() || is_null($controller = Controller::curr()) || is_null($URL = $controller->getRequest()->postVar('VanityURL'))) ? $this->owner->VanityMapping()->MappedLink : $URL;
-		$mappingExists = $this->owner->VanityMapping()->exists();
+        $vanityURL = (!Controller::has_curr() || is_null($controller = Controller::curr()) || is_null($URL = $controller->getRequest()->postVar('VanityURL'))) ? $this->owner->VanityMapping()->MappedLink : $URL;
+        $mappingExists = $this->owner->VanityMapping()->exists();
 
-		// Determine whether the vanity mapping URL has been updated.
+        // Determine whether the vanity mapping URL has been updated.
 
-		if($vanityURL && $mappingExists) {
-			if($this->owner->VanityMapping()->MappedLink !== $vanityURL) {
+        if($vanityURL && $mappingExists) {
+            if($this->owner->VanityMapping()->MappedLink !== $vanityURL) {
 
-				// Update the corresponding vanity mapping.
+                // Update the corresponding vanity mapping.
 
-				$this->owner->VanityMapping()->MappedLink = $vanityURL;
-				$this->owner->VanityMapping()->write();
-			}
-		}
+                $this->owner->VanityMapping()->MappedLink = $vanityURL;
+                $this->owner->VanityMapping()->write();
+            }
+        }
 
-		// Determine whether the vanity mapping URL has been defined.
+        // Determine whether the vanity mapping URL has been defined.
 
-		else if($vanityURL) {
+        elseif($vanityURL) {
 
-			// Instantiate the vanity mapping.
+            // Instantiate the vanity mapping.
 
-			$mapping = singleton(MisdirectionService::class)->createPageMapping($vanityURL, $this->owner->ID, 2);
-			$this->owner->VanityMappingID = $mapping->ID;
-		}
+            $mapping = singleton(MisdirectionService::class)->createPageMapping($vanityURL, $this->owner->ID, 2);
+            $this->owner->VanityMappingID = $mapping->ID;
+        }
 
-		// Determine whether the vanity mapping URL has been removed.
+        // Determine whether the vanity mapping URL has been removed.
 
-		else if($mappingExists) {
+        elseif($mappingExists) {
 
-			// Remove the corresponding vanity mapping.
+            // Remove the corresponding vanity mapping.
 
-			$this->owner->VanityMapping()->delete();
-		}
-	}
+            $this->owner->VanityMapping()->delete();
+        }
+    }
 
-	/**
-	 *	Update link mappings when replacing the default automated URL handling.
-	 */
+    /**
+     *	Update link mappings when replacing the default automated URL handling.
+     */
 
-	public function onAfterWrite() {
+    public function onAfterWrite()
+    {
 
-		parent::onAfterWrite();
+        parent::onAfterWrite();
 
-		// Determine whether the default automated URL handling has been replaced.
+        // Determine whether the default automated URL handling has been replaced.
 
-		if(Config::inst()->get(MisDirectionRequestProcessor::class, 'replace_default')) {
+        if(Config::inst()->get(MisDirectionRequestProcessor::class, 'replace_default')) {
 
-			// Determine whether the URL segment or parent ID has been updated.
+            // Determine whether the URL segment or parent ID has been updated.
 
-			$changed = $this->owner->getChangedFields();
-			if((isset($changed['URLSegment']['before']) && isset($changed['URLSegment']['after']) && ($changed['URLSegment']['before'] != $changed['URLSegment']['after'])) || (isset($changed['ParentID']['before']) && isset($changed['ParentID']['after']) && ($changed['ParentID']['before'] != $changed['ParentID']['after']))) {
+            $changed = $this->owner->getChangedFields();
+            if((isset($changed['URLSegment']['before']) && isset($changed['URLSegment']['after']) && ($changed['URLSegment']['before'] != $changed['URLSegment']['after'])) || (isset($changed['ParentID']['before']) && isset($changed['ParentID']['after']) && ($changed['ParentID']['before'] != $changed['ParentID']['after']))) {
 
-				// The link mappings should only be created for existing pages.
+                // The link mappings should only be created for existing pages.
 
-				$URL = (isset($changed['URLSegment']['before']) ? $changed['URLSegment']['before'] : $this->owner->URLSegment);
-				if(strpos($URL, 'new-') !== 0) {
+                $URL = (isset($changed['URLSegment']['before']) ? $changed['URLSegment']['before'] : $this->owner->URLSegment);
+                if(strpos($URL, 'new-') !== 0) {
 
-					// Determine the page URL.
+                    // Determine the page URL.
 
-					$parentID = (isset($changed['ParentID']['before']) ? $changed['ParentID']['before'] : $this->owner->ParentID);
-					$parent = SiteTree::get_one(SiteTree::class, "SiteTree.ID = {$parentID}");
-					while($parent) {
-						$URL = Controller::join_links($parent->URLSegment, $URL);
-						$parent = SiteTree::get_one(SiteTree::class, "SiteTree.ID = {$parent->ParentID}");
-					}
+                    $parentID = (isset($changed['ParentID']['before']) ? $changed['ParentID']['before'] : $this->owner->ParentID);
+                    $parent = SiteTree::get_one(SiteTree::class, "SiteTree.ID = {$parentID}");
+                    while($parent) {
+                        $URL = Controller::join_links($parent->URLSegment, $URL);
+                        $parent = SiteTree::get_one(SiteTree::class, "SiteTree.ID = {$parent->ParentID}");
+                    }
 
-					// Instantiate a link mapping for this page.
+                    // Instantiate a link mapping for this page.
 
-					singleton(MisdirectionService::class)->createPageMapping($URL, $this->owner->ID);
+                    singleton(MisdirectionService::class)->createPageMapping($URL, $this->owner->ID);
 
-					// Purge any link mappings that point back to the same page.
+                    // Purge any link mappings that point back to the same page.
 
-					$this->owner->regulateMappings(($this->owner->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $this->owner->Link(), $this->owner->ID);
+                    $this->owner->regulateMappings(($this->owner->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $this->owner->Link(), $this->owner->ID);
 
-					// Recursively create link mappings for any children.
+                    // Recursively create link mappings for any children.
 
-					$children = $this->owner->AllChildrenIncludingDeleted();
-					if($children->count()) {
-						$this->owner->recursiveMapping($URL, $children);
-					}
-				}
-			}
-		}
-	}
+                    $children = $this->owner->AllChildrenIncludingDeleted();
+                    if($children->count()) {
+                        $this->owner->recursiveMapping($URL, $children);
+                    }
+                }
+            }
+        }
+    }
 
-	/**
-	 *	Determine whether link mappings need to be updated when removing this page.
-	 */
+    /**
+     *	Determine whether link mappings need to be updated when removing this page.
+     */
 
-	public function onAfterDelete() {
+    public function onAfterDelete()
+    {
 
-		parent::onAfterDelete();
+        parent::onAfterDelete();
 
-		// Determine whether this page has been completely removed.
+        // Determine whether this page has been completely removed.
 
-		if(Config::inst()->get(MisDirectionRequestProcessor::class, 'replace_default') && !$this->owner->isPublished() && !$this->owner->isOnDraft()) {
+        if(Config::inst()->get(MisDirectionRequestProcessor::class, 'replace_default') && !$this->owner->isPublished() && !$this->owner->isOnDraft()) {
 
-			// Convert any link mappings that are directly associated with this page.
+            // Convert any link mappings that are directly associated with this page.
 
-			$mappings = LinkMapping::get()->filter(array(
-				'RedirectType' => 'Page',
-				'RedirectPageID' => $this->owner->ID
-			));
-			foreach($mappings as $mapping) {
-				$mapping->RedirectType = 'Link';
-				$mapping->RedirectLink = Director::makeRelative(($this->owner->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $this->owner->Link());
-				$mapping->write();
-			}
-		}
-	}
+            $mappings = LinkMapping::get()->filter([
+                'RedirectType' => 'Page',
+                'RedirectPageID' => $this->owner->ID
+            ]);
+            foreach($mappings as $mapping) {
+                $mapping->RedirectType = 'Link';
+                $mapping->RedirectLink = Director::makeRelative(($this->owner->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $this->owner->Link());
+                $mapping->write();
+            }
+        }
+    }
 
-	/**
-	 *	Purge any link mappings that point back to the same page.
-	 *
-	 *	@parameter <{PAGE_URL}> string
-	 *	@parameter <{PAGE_ID}> integer
-	 */
+    /**
+     *	Purge any link mappings that point back to the same page.
+     *
+     *	@parameter <{PAGE_URL}> string
+     *	@parameter <{PAGE_ID}> integer
+     */
 
-	public function regulateMappings($pageLink, $pageID) {
+    public function regulateMappings($pageLink, $pageID)
+    {
 
-		LinkMapping::get()->filter(array(
-			'MappedLink' => MisdirectionService::unify_URL(Director::makeRelative($pageLink)),
-			'RedirectType' => 'Page',
-			'RedirectPageID' => $pageID
-		))->removeAll();
-	}
+        LinkMapping::get()->filter([
+            'MappedLink' => MisdirectionService::unify_URL(Director::makeRelative($pageLink)),
+            'RedirectType' => 'Page',
+            'RedirectPageID' => $pageID
+        ])->removeAll();
+    }
 
-	/**
-	 *	Recursively create link mappings for any children.
-	 *
-	 *	@parameter <{BASE_URL}> string
-	 *	@parameter <{PAGE_CHILDREN}> array(site tree)
-	 */
+    /**
+     *	Recursively create link mappings for any children.
+     *
+     *	@parameter <{BASE_URL}> string
+     *	@parameter <{PAGE_CHILDREN}> array(site tree)
+     */
 
-	public function recursiveMapping($baseURL, $children) {
+    public function recursiveMapping($baseURL, $children)
+    {
 
-		foreach($children as $child) {
+        foreach($children as $child) {
 
-			// Instantiate a link mapping for this page.
+            // Instantiate a link mapping for this page.
 
-			$URL = Controller::join_links($baseURL, $child->URLSegment);
-			singleton(MisdirectionService::class)->createPageMapping($URL, $child->ID);
+            $URL = Controller::join_links($baseURL, $child->URLSegment);
+            singleton(MisdirectionService::class)->createPageMapping($URL, $child->ID);
 
-			// Purge any link mappings that point back to the same page.
+            // Purge any link mappings that point back to the same page.
 
-			$this->owner->regulateMappings(($child->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $child->Link(), $child->ID);
+            $this->owner->regulateMappings(($child->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $child->Link(), $child->ID);
 
-			// Recursively create link mappings for any children.
+            // Recursively create link mappings for any children.
 
-			$recursiveChildren = $child->AllChildrenIncludingDeleted();
-			if($recursiveChildren->count()) {
-				$this->owner->recursiveMapping($URL, $recursiveChildren);
-			}
-		}
-	}
+            $recursiveChildren = $child->AllChildrenIncludingDeleted();
+            if($recursiveChildren->count()) {
+                $this->owner->recursiveMapping($URL, $recursiveChildren);
+            }
+        }
+    }
 
 }

--- a/src/filters/MisDirectionRequestProcessor.php
+++ b/src/filters/MisDirectionRequestProcessor.php
@@ -9,7 +9,6 @@
 
 namespace nglasl\misdirection;
 
-
 use SilverStripe\Control\Director;
 use SilverStripe\Control\HTTPRequest;
 use SilverStripe\Control\HTTPResponse;
@@ -21,124 +20,123 @@ use SilverStripe\Core\Injector\Injectable;
 class MisDirectionRequestProcessor implements HTTPMiddleware
 {
 
-	use Configurable;
-	use Injectable;
+    use Configurable;
+    use Injectable;
 
-	private static $status_codes = array(
-		301 => 'Moved Permanently',
-		302 => 'Found',
-		303 => 'See Other',
-		304 => 'Not Modified',
-		305 => 'Use Proxy',
-		307 => 'Temporary Redirect',
-		308 => 'Permanent Redirect'
-	);
+    private static $status_codes = [
+        301 => 'Moved Permanently',
+        302 => 'Found',
+        303 => 'See Other',
+        304 => 'Not Modified',
+        305 => 'Use Proxy',
+        307 => 'Temporary Redirect',
+        308 => 'Permanent Redirect'
+    ];
 
-	public $service;
+    public $service;
 
-	private static $dependencies = array(
-		'service' => '%$' . MisdirectionService::class
-	);
+    private static $dependencies = [
+        'service' => '%$' . MisdirectionService::class
+    ];
 
-	private static $enforce_misdirection = true;
+    private static $enforce_misdirection = true;
 
-	private static $replace_default = false;
+    private static $replace_default = false;
 
-	/**
-	 *	The maximum number of consecutive link mappings.
-	 */
-	private static $maximum_requests = 9;
+    /**
+     *	The maximum number of consecutive link mappings.
+     */
+    private static $maximum_requests = 9;
 
-	public function process(HTTPRequest $request, callable $delegate)
-	{
-		/* @var $response HTTPResponse */
-		$response = $delegate($request);
-		$requestURL = $request->getURL();
-		$bypass = array(
-			'admin',
-			'Security',
-			'CMSSecurity',
-			'dev'
-		);
+    public function process(HTTPRequest $request, callable $delegate)
+    {
+        /* @var $response HTTPResponse */
+        $response = $delegate($request);
+        $requestURL = $request->getURL();
+        $bypass = [
+            'admin',
+            'Security',
+            'CMSSecurity',
+            'dev'
+        ];
 
-		foreach(Director::config()->get('rules') as $segment => $controller) {
+        foreach(Director::config()->get('rules') as $segment => $controller) {
 
-			// Retrieve the specific director rules.
+            // Retrieve the specific director rules.
 
-			if(($position = strpos($segment, '$')) !== false) {
-				$segment = rtrim(substr($segment, 0, $position), '/');
-			}
+            if(($position = strpos($segment, '$')) !== false) {
+                $segment = rtrim(substr($segment, 0, $position), '/');
+            }
 
-			// Determine if the current request matches a specific director rule.
+            // Determine if the current request matches a specific director rule.
 
-			if($segment && in_array($segment, $bypass) && (($requestURL === $segment) || (strpos($requestURL, "{$segment}/") === 0))) {
+            if($segment && in_array($segment, $bypass) && (($requestURL === $segment) || (strpos($requestURL, "{$segment}/") === 0))) {
 
-				// Continue processing the response.
-				return $response;
-			}
+                // Continue processing the response.
+                return $response;
+            }
 
-			if($request->getVar('misdirected') || $request->getVar('direct')) {
+            if($request->getVar('misdirected') || $request->getVar('direct')) {
 
-				// Continue processing the response.
-				return $response;
-			}
-		}
+                // Continue processing the response.
+                return $response;
+            }
+        }
 
-		if($response) {
+        if($response) {
 
-			$status = $response ? $response->getStatusCode() : null;
-			$success = (($status >= 200) && ($status < 300));
-			$error = ($status === 404);
+            $status = $response ? $response->getStatusCode() : null;
+            $success = (($status >= 200) && ($status < 300));
+            $error = ($status === 404);
 
-			$enforce = $this->config()->get('enforce_misdirection');
-			$replace = $this->config()->get('replace_default');
+            $enforce = $this->config()->get('enforce_misdirection');
+            $replace = $this->config()->get('replace_default');
 
-			if(($error || $enforce || $replace) && ($map = $this->service->getMappingByRequest($request))) {
+            if(($error || $enforce || $replace) && ($map = $this->service->getMappingByRequest($request))) {
 
-				$responseCode = $map->ResponseCode;
-				if($responseCode == 0) {
-					$responseCode = 301;
-				}
+                $responseCode = $map->ResponseCode;
+                if($responseCode == 0) {
+                    $responseCode = 301;
+                }
 
-				$link = $map->getLink();
-				$base = Director::baseURL();
-				if($replace && (substr($link, 0, strlen($base)) === $base) && (substr($link, strlen($base)) === 'home/')) {
-					$link = $base;
-				}
+                $link = $map->getLink();
+                $base = Director::baseURL();
+                if($replace && (substr($link, 0, strlen($base)) === $base) && (substr($link, strlen($base)) === 'home/')) {
+                    $link = $base;
+                }
 
-				// Update the response using the link mapping redirection.
+                // Update the response using the link mapping redirection.
 
-				$response->setBody('');
-				$response->redirect($link, $responseCode);
-			}
-			else if($error && ($fallback = $this->service->determineFallback($requestURL))) {
+                $response->setBody('');
+                $response->redirect($link, $responseCode);
+            } elseif($error && ($fallback = $this->service->determineFallback($requestURL))) {
 
-				// Update the response code where appropriate.
+                // Update the response code where appropriate.
 
-				$responseCode = $fallback['code'];
-				if($responseCode === 0) {
-					$responseCode = 303;
-				}
+                $responseCode = $fallback['code'];
+                if($responseCode === 0) {
+                    $responseCode = 303;
+                }
 
-				// Update the response using the fallback, enforcing no further redirection.
+                // Update the response using the fallback, enforcing no further redirection.
 
-				$response->setBody('');
-				$response->redirect($fallback['link'], $responseCode);
-			}
+                $response->setBody('');
+                $response->redirect($fallback['link'], $responseCode);
+            }
 
-			// When enabled, replace the default automated URL handling with a page not found.
+            // When enabled, replace the default automated URL handling with a page not found.
 
-			else if(!$error && !$success && $replace) {
-				$response->setStatusCode(404);
+            elseif(!$error && !$success && $replace) {
+                $response->setStatusCode(404);
 
-				// Retrieve the appropriate page not found response.
+                // Retrieve the appropriate page not found response.
 
-				(ClassInfo::exists(SiteTree::class) && ($page = ErrorPage::response_for(404))) ? $response->setBody($page->getBody()) : $response->setBody('No URL was matched!');
-			}
+                (ClassInfo::exists(SiteTree::class) && ($page = ErrorPage::response_for(404))) ? $response->setBody($page->getBody()) : $response->setBody('No URL was matched!');
+            }
 
-		}
-		return $response;
+        }
+        return $response;
 
-	}
+    }
 
 }

--- a/src/forms/MisdirectionTesting.php
+++ b/src/forms/MisdirectionTesting.php
@@ -9,16 +9,18 @@ use SilverStripe\Forms\GridField\GridField_HTMLProvider;
  *	@author Nathan Glasl <nathan@symbiote.com.au>
  */
 
-class MisdirectionTesting implements GridField_HTMLProvider {
+class MisdirectionTesting implements GridField_HTMLProvider
+{
 
-	/**
-	 *	Render the URL input and test button.
-	 */
+    /**
+     *	Render the URL input and test button.
+     */
 
-	public function getHTMLFragments($gridfield) {
+    public function getHTMLFragments($gridfield)
+    {
 
-		return array(
-			'before' => "<div class='misdirection-testing admin'>
+        return [
+            'before' => "<div class='misdirection-testing admin'>
 				<div><strong>Test Link Mappings</strong></div>
 				<div class='wrapper'>
 					<input type='text' class='text w-50 url' spellcheck='false'/>
@@ -28,7 +30,7 @@ class MisdirectionTesting implements GridField_HTMLProvider {
 				</div>
 				<div class='results'></div>
 			</div>"
-		);
-	}
+        ];
+    }
 
 }

--- a/src/services/MisdirectionService.php
+++ b/src/services/MisdirectionService.php
@@ -18,404 +18,410 @@ use Symbiote\Multisites\Multisites;
  *	@author Nathan Glasl <nathan@symbiote.com.au>
  */
 
-class MisdirectionService {
-
-	/**
-	 *	Unifies a URL so link mappings are predictable.
-	 *
-	 *	@parameter <{URL}> string
-	 *	@return string
-	 */
+class MisdirectionService
+{
+
+    /**
+     *	Unifies a URL so link mappings are predictable.
+     *
+     *	@parameter <{URL}> string
+     *	@return string
+     */
+
+    public static function unify_URL($URL)
+    {
+
+        return strtolower(trim($URL, ' ?/'));
+    }
+
+    /**
+     *	Use third party validation to determine an external URL (https://gist.github.com/dperini/729294 and http://mathiasbynens.be/demo/url-regex).
+     *
+     *	@parameter <{URL}> string
+     *	@return boolean
+     */
+
+    public static function is_external_URL($URL)
+    {
+
+        $URL = trim($URL, '/?!"#$%&\'()*+,-.@:;<=>[\\]^_`{|}~');
+        return preg_match('%^(?:(?:https?|ftp)://)(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?$%iu', $URL);
+    }
+
+    /**
+     *	Retrieve the appropriate link mapping for a request, with the ability to enable testing and return the recursion stack.
+     *
+     *	@parameter <{REQUEST}> http request
+     *	@parameter <{RETURN_STACK}> boolean
+     *	@return link mapping
+     */
 
-	public static function unify_URL($URL) {
-
-		return strtolower(trim($URL, ' ?/'));
-	}
-
-	/**
-	 *	Use third party validation to determine an external URL (https://gist.github.com/dperini/729294 and http://mathiasbynens.be/demo/url-regex).
-	 *
-	 *	@parameter <{URL}> string
-	 *	@return boolean
-	 */
+    public function getMappingByRequest($request, $testing = false)
+    {
 
-	public static function is_external_URL($URL) {
+        // Make sure a URL comes through correctly.
+
+        $link = str_replace([
+            ':/',
+            ' '
+        ], [
+            '://',
+            '%20'
+        ], $request->getURL(true));
+        $host = $request->getHeader('Host');
 
-		$URL = trim($URL, '/?!"#$%&\'()*+,-.@:;<=>[\\]^_`{|}~');
-		return preg_match('%^(?:(?:https?|ftp)://)(?:\S+(?::\S*)?@|\d{1,3}(?:\.\d{1,3}){3}|(?:(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)(?:\.(?:[a-z\d\x{00a1}-\x{ffff}]+-?)*[a-z\d\x{00a1}-\x{ffff}]+)*(?:\.[a-z\x{00a1}-\x{ffff}]{2,6}))(?::\d+)?(?:[^\s]*)?$%iu', $URL);
-	}
+        // Retrieve the appropriate link mapping.
 
-	/**
-	 *	Retrieve the appropriate link mapping for a request, with the ability to enable testing and return the recursion stack.
-	 *
-	 *	@parameter <{REQUEST}> http request
-	 *	@parameter <{RETURN_STACK}> boolean
-	 *	@return link mapping
-	 */
+        $map = $this->getMapping($link, $host);
 
-	public function getMappingByRequest($request, $testing = false) {
+        // Traverse the link mapping chain and return the eventual result, preventing multiple redirections.
 
-		// Make sure a URL comes through correctly.
+        return $map ? $this->getRecursiveMapping($map, $host, $testing) : null;
+    }
 
-		$link = str_replace(array(
-			':/',
-			' '
-		), array(
-			'://',
-			'%20'
-		), $request->getURL(true));
-		$host = $request->getHeader('Host');
+    /**
+     *	Retrieve the appropriate link mapping for a URL.
+     *
+     *	@parameter <{URL}> string
+     *	@parameter <{HOSTNAME}> string
+     *	@return link mapping
+     */
 
-		// Retrieve the appropriate link mapping.
+    public function getMapping($URL, $host = null)
+    {
 
-		$map = $this->getMapping($link, $host);
+        $URL = self::is_external_URL($URL) ? parse_url($URL, PHP_URL_PATH) : Director::makeRelative($URL);
+        $URL = self::unify_URL($URL);
+        $parts = explode('?', $URL);
+
+        // Instantiate the link mapping query.
+
+        $matches = LinkMapping::get();
+
+        // Enforce any hostname restriction that may have been defined.
+
+        if(is_null($host) && Controller::has_curr() && ($controller = Controller::curr())) {
+            $host = $controller->getRequest()->getHeader('Host');
+        }
+        $temporary = $host;
+        $host = Convert::raw2sql($host);
+        $matches = $matches->where("(HostnameRestriction IS NULL) OR (HostnameRestriction = '{$host}')");
+        $regex = clone $matches;
+
+        // Determine the simple matching from the database.
 
-		// Traverse the link mapping chain and return the eventual result, preventing multiple redirections.
+        $base = Convert::raw2sql($parts[0]);
+        $matches = $matches->where("(LinkType = 'Simple') AND (((IncludesHostname = 0) AND ((MappedLink = '{$base}') OR (MappedLink LIKE '{$base}?%'))) OR ((IncludesHostname = 1) AND ((MappedLink = '{$host}/{$base}') OR (MappedLink LIKE '{$host}/{$base}?%'))))");
+        $host = $temporary;
 
-		return $map ? $this->getRecursiveMapping($map, $host, $testing) : null;
-	}
+        // Determine the remaining regular expression matching, as this is inconsistent from the database.
 
-	/**
-	 *	Retrieve the appropriate link mapping for a URL.
-	 *
-	 *	@parameter <{URL}> string
-	 *	@parameter <{HOSTNAME}> string
-	 *	@return link mapping
-	 */
+        $regex = $regex->filter('LinkType', 'Regular Expression');
+        $filtered = ArrayList::create();
+        foreach($regex as $match) {
+            if((!$match->IncludesHostname && preg_match("%{$match->MappedLink}%", $URL)) || ($match->IncludesHostname && preg_match("%{$match->MappedLink}%", "{$host}/{$URL}"))) {
+                $filtered->push($match);
+            }
+        }
+        $filtered->merge($matches);
+        $matches = $filtered;
+
+        // Make sure the link mappings are ordered by priority and specificity.
+
+        $matches = $matches->sort([
+            'Priority' => 'DESC',
+            'LinkType' => 'DESC',
+            'MappedLink' => 'DESC',
+            'ID' => Config::inst()->get(LinkMapping::class, 'priority')
+        ]);
 
-	public function getMapping($URL, $host = null) {
+        // Determine which link mapping should be returned, based on the sort order.
 
-		$URL = self::is_external_URL($URL) ? parse_url($URL, PHP_URL_PATH) : Director::makeRelative($URL);
-		$URL = self::unify_URL($URL);
-		$parts = explode('?', $URL);
+        $queryParameters = [];
+        if(isset($parts[1])) {
+            parse_str($parts[1], $queryParameters);
+        }
+        foreach($matches as $match) {
 
-		// Instantiate the link mapping query.
+            // Make sure the link mapping is live on the current stage.
+
+            if($match->isLive() !== 'false') {
 
-		$matches = LinkMapping::get();
-
-		// Enforce any hostname restriction that may have been defined.
+                // Ignore GET parameter matching for regular expressions, considering the special characters.
+
+                $matchParts = explode('?', $match->MappedLink);
+                if(($match->LinkType === 'Simple') && isset($matchParts[1])) {
 
-		if(is_null($host) && Controller::has_curr() && ($controller = Controller::curr())) {
-			$host = $controller->getRequest()->getHeader('Host');
-		}
-		$temporary = $host;
-		$host = Convert::raw2sql($host);
-		$matches = $matches->where("(HostnameRestriction IS NULL) OR (HostnameRestriction = '{$host}')");
-		$regex = clone $matches;
+                    // Make sure the GET parameters match in any order.
 
-		// Determine the simple matching from the database.
+                    $matchParameters = [];
+                    parse_str($matchParts[1], $matchParameters);
+                    if($matchParameters == $queryParameters) {
+                        return $match;
+                    }
+                } else {
 
-		$base = Convert::raw2sql($parts[0]);
-		$matches = $matches->where("(LinkType = 'Simple') AND (((IncludesHostname = 0) AND ((MappedLink = '{$base}') OR (MappedLink LIKE '{$base}?%'))) OR ((IncludesHostname = 1) AND ((MappedLink = '{$host}/{$base}') OR (MappedLink LIKE '{$host}/{$base}?%'))))");
-		$host = $temporary;
+                    // Return the first link mapping when GET parameters aren't present.
 
-		// Determine the remaining regular expression matching, as this is inconsistent from the database.
+                    $match->setMatchedURL($match->IncludesHostname ? "{$host}/{$URL}" : $URL);
+                    return $match;
+                }
+            }
+        }
 
-		$regex = $regex->filter('LinkType', 'Regular Expression');
-		$filtered = ArrayList::create();
-		foreach($regex as $match) {
-			if((!$match->IncludesHostname && preg_match("%{$match->MappedLink}%", $URL)) || ($match->IncludesHostname && preg_match("%{$match->MappedLink}%", "{$host}/{$URL}"))) {
-				$filtered->push($match);
-			}
-		}
-		$filtered->merge($matches);
-		$matches = $filtered;
+        // No mapping has been found.
 
-		// Make sure the link mappings are ordered by priority and specificity.
+        return null;
+    }
 
-		$matches = $matches->sort(array(
-			'Priority' => 'DESC',
-			'LinkType' => 'DESC',
-			'MappedLink' => 'DESC',
-			'ID' => Config::inst()->get(LinkMapping::class, 'priority')
-		));
+    /**
+     *	Traverse the link mapping chain and return the eventual result, preventing multiple redirections.
+     *
+     *	@parameter <{LINK_MAPPING}> link mapping
+     *	@parameter <{HOSTNAME}> string
+     *	@parameter <{RETURN_STACK}> boolean
+     *	@return link mapping/array
+     */
 
-		// Determine which link mapping should be returned, based on the sort order.
+    public function getRecursiveMapping($map, $host = null, $testing = false)
+    {
 
-		$queryParameters = array();
-		if(isset($parts[1])) {
-			parse_str($parts[1], $queryParameters);
-		}
-		foreach($matches as $match) {
+        // Keep track of the link mapping recursion.
+
+        $counter = 1;
+        $redirect = $map->getLink();
+        $chain = [
+            array_merge($map->toMap(), [
+                'Counter' => $counter,
+                'RedirectLink' => $map->getLinkSummary(),
+                'LinkMapping' => $map
+            ])
+        ];
+
+        // Determine the subsequent host.
+
+        if($map->getLinkHost()) {
+            $host = $map->getLinkHost();
+        }
+
+        // Determine the next link mapping, immediately redirecting towards an external URL.
 
-			// Make sure the link mapping is live on the current stage.
+        while((($map->RedirectType === 'Page') || !self::is_external_URL($redirect)) && ($next = $this->getMapping($redirect, $host))) {
 
-			if($match->isLive() !== 'false') {
+            // Enforce a maximum number of redirects, preventing infinite recursion and inefficient link mappings.
 
-				// Ignore GET parameter matching for regular expressions, considering the special characters.
+            if($counter === Config::inst()->get(MisDirectionRequestProcessor::class, 'maximum_requests')) {
+                $chain[] = [
+                    'ResponseCode' => 404
+                ];
+
+                // Return the call stack when testing has been enabled.
+
+                return $testing ? $chain : null;
+            }
+            $redirect = $next->getLink();
+            $chain[] = array_merge($next->toMap(), [
+                'Counter' => ++$counter,
+                'RedirectLink' => $next->getLinkSummary(),
+                'LinkMapping' => $next
+            ]);
 
-				$matchParts = explode('?', $match->MappedLink);
-				if(($match->LinkType === 'Simple') && isset($matchParts[1])) {
+            // Determine the subsequent host.
 
-					// Make sure the GET parameters match in any order.
+            if($next->getLinkHost()) {
+                $host = $next->getLinkHost();
+            }
+            $map = $next;
+        }
 
-					$matchParameters = array();
-					parse_str($matchParts[1], $matchParameters);
-					if($matchParameters == $queryParameters) {
-						return $match;
-					}
-				}
-				else {
+        // Return either the call stack when testing has been enabled, or the eventual link mapping result.
+
+        return $testing ? $chain : $map;
+    }
 
-					// Return the first link mapping when GET parameters aren't present.
-
-					$match->setMatchedURL($match->IncludesHostname ? "{$host}/{$URL}" : $URL);
-					return $match;
-				}
-			}
-		}
-
-		// No mapping has been found.
-
-		return null;
-	}
-
-	/**
-	 *	Traverse the link mapping chain and return the eventual result, preventing multiple redirections.
-	 *
-	 *	@parameter <{LINK_MAPPING}> link mapping
-	 *	@parameter <{HOSTNAME}> string
-	 *	@parameter <{RETURN_STACK}> boolean
-	 *	@return link mapping/array
-	 */
-
-	public function getRecursiveMapping($map, $host = null, $testing = false) {
-
-		// Keep track of the link mapping recursion.
-
-		$counter = 1;
-		$redirect = $map->getLink();
-		$chain = array(
-			array_merge($map->toMap(), array(
-				'Counter' => $counter,
-				'RedirectLink' => $map->getLinkSummary(),
-				'LinkMapping' => $map
-			))
-		);
-
-		// Determine the subsequent host.
-
-		if($map->getLinkHost()) {
-			$host = $map->getLinkHost();
-		}
-
-		// Determine the next link mapping, immediately redirecting towards an external URL.
-
-		while((($map->RedirectType === 'Page') || !self::is_external_URL($redirect)) && ($next = $this->getMapping($redirect, $host))) {
-
-			// Enforce a maximum number of redirects, preventing infinite recursion and inefficient link mappings.
-
-			if($counter === Config::inst()->get(MisDirectionRequestProcessor::class, 'maximum_requests')) {
-				$chain[] = array(
-					'ResponseCode' => 404
-				);
-
-				// Return the call stack when testing has been enabled.
-
-				return $testing ? $chain : null;
-			}
-			$redirect = $next->getLink();
-			$chain[] = array_merge($next->toMap(), array(
-				'Counter' => ++$counter,
-				'RedirectLink' => $next->getLinkSummary(),
-				'LinkMapping' => $next
-			));
-
-			// Determine the subsequent host.
-
-			if($next->getLinkHost()) {
-				$host = $next->getLinkHost();
-			}
-			$map = $next;
-		}
-
-		// Return either the call stack when testing has been enabled, or the eventual link mapping result.
-
-		return $testing ? $chain : $map;
-	}
-
-	/**
-	 *	Determine the fallback for a URL when the CMS module is present.
-	 *
-	 *	@parameter <{URL}> string
-	 *	@return array(string, integer)
-	 */
-
-	public function determineFallback($URL) {
-
-		// Make sure the CMS module is present.
-
-		if(ClassInfo::exists(SiteTree::class) && $URL) {
-
-			// Instantiate the required variables.
-
-			$segments = explode('/', self::unify_URL($URL));
-			$applicableRule = null;
-			$nearestParent = null;
-			$thisPage = null;
-			$toURL = null;
-			$responseCode = 303;
-
-			// This prevents a page not found from redirecting back to the same page.
-
-			array_pop($segments);
-
-			// Retrieve the default site configuration fallback.
-
-			$config = SiteConfig::current_site_config();
-			if($config && $config->Fallback) {
-				$applicableRule = $config->Fallback;
-				$nearestParent = $thisPage = Director::baseURL();
-				$toURL = $config->FallbackLink;
-				$responseCode = $config->FallbackResponseCode;
-			}
-
-			// This is required to support multiple sites.
-
-			if(ClassInfo::exists(Multisites::class) && ($parent = Multisites::inst()->getCurrentSite())) {
-				$parentID = $parent->ID;
-				if($parent->Fallback) {
-					$applicableRule = $parent->Fallback;
-					$nearestParent = $thisPage = Director::baseURL();
-					$toURL = $parent->FallbackLink;
-					$responseCode = $parent->FallbackResponseCode;
-				}
-			}
-			else {
-				$parentID = 0;
-			}
-
-			// Determine the page specific fallback.
-
-			for($iteration = 0; $iteration < count($segments); $iteration++) {
-				$page = SiteTree::get()->filter(array(
-					'URLSegment' => $segments[$iteration],
-					'ParentID' => $parentID
-				))->first();
-				if($page) {
-
-					// Determine the home page URL when appropriate.
-
-					$link = ($page->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $page->Link();
-					$nearestParent = $link;
-
-					// Keep track of the current page fallback.
-
-					if($page->Fallback) {
-						$applicableRule = $page->Fallback;
-						$thisPage = $link;
-						$toURL = $page->FallbackLink;
-						$responseCode = $page->FallbackResponseCode;
-					}
-					$parentID = $page->ID;
-				}
-				else {
-
-					// The bottom of the chain has been reached.
-
-					break;
-				}
-			}
-
-			// Determine the applicable fallback.
-
-			if($applicableRule) {
-				$link = null;
-				switch($applicableRule) {
-
-					// Bypass the request filter.
-
-					case 'Nearest':
-						$link = '/' . HTTP::setGetVar('misdirected', true, $nearestParent);
-						break;
-					case 'This':
-						$link = '/' . HTTP::setGetVar('misdirected', true, $thisPage);
-						break;
-					case 'URL':
-
-						// When appropriate, prepend the base URL to match a page redirection.
-
-						$link = self::is_external_URL($toURL) ? (ClassInfo::exists(Multisites::class) ? HTTP::setGetVar('misdirected', true, $toURL) : $toURL) : ('/' . HTTP::setGetVar('misdirected', true, Controller::join_links(Director::baseURL(), $toURL)));
-						break;
-				}
-				if($link) {
-					return array(
-						'link' => $link,
-						'code' => (int)$responseCode
-					);
-				}
-			}
-		}
-
-		// No fallback has been found.
-
-		return null;
-	}
-
-	/**
-	 *	Instantiate a new link mapping, redirecting a URL towards a page.
-	 *
-	 *	@parameter <{MAPPING_URL}> string
-	 *	@parameter <{MAPPING_PAGE_ID}> integer
-	 *	@parameter <{MAPPING_PRIORITY}> integer
-	 *	@return link mapping
-	 */
-
-	public function createPageMapping($URL, $redirectID, $priority = 1) {
-
-		// Retrieve an already existing link mapping if one exists.
-
-		$existing = LinkMapping::get()->filter(array(
-			'MappedLink' => $URL,
-			'RedirectType' => 'Page',
-			'RedirectPageID' => $redirectID
-		))->first();
-		if($existing) {
-			return $existing;
-		}
-
-		// Instantiate the new link mapping with appropriate default values.
-
-		$mapping = LinkMapping::create();
-		$mapping->MappedLink = $URL;
-		$mapping->RedirectType = 'Page';
-		$mapping->RedirectPageID = (int)$redirectID;
-		$mapping->Priority = (int)$priority;
-		$mapping->write();
-		return $mapping;
-	}
-
-	/**
-	 *	Instantiate a new link mapping, redirecting a URL towards another URL.
-	 *
-	 *	@parameter <{MAPPING_URL}> string
-	 *	@parameter <{MAPPING_REDIRECT_URL}> string
-	 *	@parameter <{MAPPING_PRIORITY}> integer
-	 *	@return link mapping
-	 */
-
-	public function createURLMapping($URL, $redirectURL, $priority = 1) {
-
-		// Retrieve an already existing link mapping if one exists.
-
-		$existing = LinkMapping::get()->filter(array(
-			'MappedLink' => $URL,
-			'RedirectType' => 'Link',
-			'RedirectLink' => $redirectURL
-		))->first();
-		if($existing) {
-			return $existing;
-		}
-
-		// Instantiate the new link mapping with appropriate default values.
-
-		$mapping = LinkMapping::create();
-		$mapping->MappedLink = $URL;
-		$mapping->RedirectType = 'Link';
-		$mapping->RedirectLink = $redirectURL;
-		$mapping->Priority = (int)$priority;
-		$mapping->write();
-		return $mapping;
-	}
+    /**
+     *	Determine the fallback for a URL when the CMS module is present.
+     *
+     *	@parameter <{URL}> string
+     *	@return array(string, integer)
+     */
+
+    public function determineFallback($URL)
+    {
+
+        // Make sure the CMS module is present.
+
+        if(ClassInfo::exists(SiteTree::class) && $URL) {
+
+            // Instantiate the required variables.
+
+            $segments = explode('/', self::unify_URL($URL));
+            $applicableRule = null;
+            $nearestParent = null;
+            $thisPage = null;
+            $toURL = null;
+            $responseCode = 303;
+
+            // This prevents a page not found from redirecting back to the same page.
+
+            array_pop($segments);
+
+            // Retrieve the default site configuration fallback.
+
+            $config = SiteConfig::current_site_config();
+            if($config && $config->Fallback) {
+                $applicableRule = $config->Fallback;
+                $nearestParent = $thisPage = Director::baseURL();
+                $toURL = $config->FallbackLink;
+                $responseCode = $config->FallbackResponseCode;
+            }
+
+            // This is required to support multiple sites.
+
+            if(ClassInfo::exists(Multisites::class) && ($parent = Multisites::inst()->getCurrentSite())) {
+                $parentID = $parent->ID;
+                if($parent->Fallback) {
+                    $applicableRule = $parent->Fallback;
+                    $nearestParent = $thisPage = Director::baseURL();
+                    $toURL = $parent->FallbackLink;
+                    $responseCode = $parent->FallbackResponseCode;
+                }
+            } else {
+                $parentID = 0;
+            }
+
+            // Determine the page specific fallback.
+
+            for($iteration = 0; $iteration < count($segments); $iteration++) {
+                $page = SiteTree::get()->filter([
+                    'URLSegment' => $segments[$iteration],
+                    'ParentID' => $parentID
+                ])->first();
+                if($page) {
+
+                    // Determine the home page URL when appropriate.
+
+                    $link = ($page->Link() === Director::baseURL()) ? Controller::join_links(Director::baseURL(), 'home/') : $page->Link();
+                    $nearestParent = $link;
+
+                    // Keep track of the current page fallback.
+
+                    if($page->Fallback) {
+                        $applicableRule = $page->Fallback;
+                        $thisPage = $link;
+                        $toURL = $page->FallbackLink;
+                        $responseCode = $page->FallbackResponseCode;
+                    }
+                    $parentID = $page->ID;
+                } else {
+
+                    // The bottom of the chain has been reached.
+
+                    break;
+                }
+            }
+
+            // Determine the applicable fallback.
+
+            if($applicableRule) {
+                $link = null;
+                switch($applicableRule) {
+
+                    // Bypass the request filter.
+
+                    case 'Nearest':
+                        $link = '/' . HTTP::setGetVar('misdirected', true, $nearestParent);
+                        break;
+                    case 'This':
+                        $link = '/' . HTTP::setGetVar('misdirected', true, $thisPage);
+                        break;
+                    case 'URL':
+
+                        // When appropriate, prepend the base URL to match a page redirection.
+
+                        $link = self::is_external_URL($toURL) ? (ClassInfo::exists(Multisites::class) ? HTTP::setGetVar('misdirected', true, $toURL) : $toURL) : ('/' . HTTP::setGetVar('misdirected', true, Controller::join_links(Director::baseURL(), $toURL)));
+                        break;
+                }
+                if($link) {
+                    return [
+                        'link' => $link,
+                        'code' => (int)$responseCode
+                    ];
+                }
+            }
+        }
+
+        // No fallback has been found.
+
+        return null;
+    }
+
+    /**
+     *	Instantiate a new link mapping, redirecting a URL towards a page.
+     *
+     *	@parameter <{MAPPING_URL}> string
+     *	@parameter <{MAPPING_PAGE_ID}> integer
+     *	@parameter <{MAPPING_PRIORITY}> integer
+     *	@return link mapping
+     */
+
+    public function createPageMapping($URL, $redirectID, $priority = 1)
+    {
+
+        // Retrieve an already existing link mapping if one exists.
+
+        $existing = LinkMapping::get()->filter([
+            'MappedLink' => $URL,
+            'RedirectType' => 'Page',
+            'RedirectPageID' => $redirectID
+        ])->first();
+        if($existing) {
+            return $existing;
+        }
+
+        // Instantiate the new link mapping with appropriate default values.
+
+        $mapping = LinkMapping::create();
+        $mapping->MappedLink = $URL;
+        $mapping->RedirectType = 'Page';
+        $mapping->RedirectPageID = (int)$redirectID;
+        $mapping->Priority = (int)$priority;
+        $mapping->write();
+        return $mapping;
+    }
+
+    /**
+     *	Instantiate a new link mapping, redirecting a URL towards another URL.
+     *
+     *	@parameter <{MAPPING_URL}> string
+     *	@parameter <{MAPPING_REDIRECT_URL}> string
+     *	@parameter <{MAPPING_PRIORITY}> integer
+     *	@return link mapping
+     */
+
+    public function createURLMapping($URL, $redirectURL, $priority = 1)
+    {
+
+        // Retrieve an already existing link mapping if one exists.
+
+        $existing = LinkMapping::get()->filter([
+            'MappedLink' => $URL,
+            'RedirectType' => 'Link',
+            'RedirectLink' => $redirectURL
+        ])->first();
+        if($existing) {
+            return $existing;
+        }
+
+        // Instantiate the new link mapping with appropriate default values.
+
+        $mapping = LinkMapping::create();
+        $mapping->MappedLink = $URL;
+        $mapping->RedirectType = 'Link';
+        $mapping->RedirectLink = $redirectURL;
+        $mapping->Priority = (int)$priority;
+        $mapping->write();
+        return $mapping;
+    }
 
 }

--- a/tests/FunctionalTests.php
+++ b/tests/FunctionalTests.php
@@ -18,125 +18,126 @@ use Symbiote\Multisites\Multisites;
  *	@author Nathan Glasl <nathan@symbiote.com.au>
  */
 
-class FunctionalTests extends FunctionalTest {
+class FunctionalTests extends FunctionalTest
+{
 
-	protected $usesDatabase = true;
+    protected $usesDatabase = true;
 
-	/**
-	 *	This is to prevent following the request filter's redirect.
-	 */
+    /**
+     *	This is to prevent following the request filter's redirect.
+     */
 
-	protected $autoFollowRedirection = false;
+    protected $autoFollowRedirection = false;
 
-	/**
-	 *	The test to ensure the request filter is functioning correctly.
-	 */
+    /**
+     *	The test to ensure the request filter is functioning correctly.
+     */
 
-	public function testRequestFilter() {
+    public function testRequestFilter()
+    {
 
-		// Instantiate link mappings to use.
+        // Instantiate link mappings to use.
 
-		$mapping = LinkMapping::create(
-			array(
-				'LinkType' => 'Simple',
-				'MappedLink' => 'wrong/page',
-				'RedirectLink' => 'pending'
-			)
-		);
-		$mapping->write();
-		LinkMapping::create(
-			array(
-				'LinkType' => 'Simple',
-				'MappedLink' => 'pending',
-				'RedirectLink' => 'correct/page'
-			)
-		)->write();
+        $mapping = LinkMapping::create(
+            [
+                'LinkType' => 'Simple',
+                'MappedLink' => 'wrong/page',
+                'RedirectLink' => 'pending'
+            ]
+        );
+        $mapping->write();
+        LinkMapping::create(
+            [
+                'LinkType' => 'Simple',
+                'MappedLink' => 'pending',
+                'RedirectLink' => 'correct/page'
+            ]
+        )->write();
 
-		// The CMS module needs to be present to test page behaviour.
+        // The CMS module needs to be present to test page behaviour.
 
-		if(ClassInfo::exists(SiteTree::class)) {
+        if(ClassInfo::exists(SiteTree::class)) {
 
-			// This is required to support multiple sites.
+            // This is required to support multiple sites.
 
-			$this->logInAs(Member::default_admin());
-			$parentID = ClassInfo::exists(Multisites::class) ? Multisites::inst()->getCurrentSiteId() : 0;
+            $this->logInAs(Member::default_admin());
+            $parentID = ClassInfo::exists(Multisites::class) ? Multisites::inst()->getCurrentSiteId() : 0;
 
-			// Instantiate pages to use.
+            // Instantiate pages to use.
 
-			$first = SiteTree::create(
-				array(
-					'URLSegment' => 'wrong',
-					'ParentID' => $parentID
-				)
-			);
-			$first->writeToStage('Stage');
-			$first->publishRecursive();
-			$second = SiteTree::create(
-				array(
-					'URLSegment' => 'page',
-					'ParentID' => $first->ID
-				)
-			);
-			$second->writeToStage('Stage');
-			$second->publishRecursive();
-		}
+            $first = SiteTree::create(
+                [
+                    'URLSegment' => 'wrong',
+                    'ParentID' => $parentID
+                ]
+            );
+            $first->writeToStage('Stage');
+            $first->publishRecursive();
+            $second = SiteTree::create(
+                [
+                    'URLSegment' => 'page',
+                    'ParentID' => $first->ID
+                ]
+            );
+            $second->writeToStage('Stage');
+            $second->publishRecursive();
+        }
 
-		// Determine whether the enforce misdirection is functioning correctly.
+        // Determine whether the enforce misdirection is functioning correctly.
 
-		$response = $this->get('wrong/page');
-		$this->assertEquals($response->getStatusCode(), 301);
-		$this->assertEquals($response->getHeader('Location'), '/correct/page');
+        $response = $this->get('wrong/page');
+        $this->assertEquals($response->getStatusCode(), 301);
+        $this->assertEquals($response->getHeader('Location'), '/correct/page');
 
-		// The CMS module needs to be present to test page behaviour.
+        // The CMS module needs to be present to test page behaviour.
 
-		if(ClassInfo::exists(SiteTree::class)) {
+        if(ClassInfo::exists(SiteTree::class)) {
 
-			// Update the default enforce misdirection.
+            // Update the default enforce misdirection.
 
-			Config::modify()->set(MisDirectionRequestProcessor::class, 'enforce_misdirection', false);
+            Config::modify()->set(MisDirectionRequestProcessor::class, 'enforce_misdirection', false);
 
-			// Determine whether the page is now matched.
+            // Determine whether the page is now matched.
 
-			$response = $this->get('wrong/page');
-			$this->assertEquals($response->getStatusCode(), 200);
-			$this->assertEquals($response->getHeader('Location'), null);
+            $response = $this->get('wrong/page');
+            $this->assertEquals($response->getStatusCode(), 200);
+            $this->assertEquals($response->getHeader('Location'), null);
 
-			// Instantiate a fallback to use.
+            // Instantiate a fallback to use.
 
-			$first->Fallback = 'Nearest';
-			$first->writeToStage('Stage');
-			$first->publishRecursive();
+            $first->Fallback = 'Nearest';
+            $first->writeToStage('Stage');
+            $first->publishRecursive();
 
-			// The database needs to be cleaned up to prevent further testing conflict.
+            // The database needs to be cleaned up to prevent further testing conflict.
 
-			$second->deleteFromStage('Live');
-			$second->deleteFromStage('Stage');
-			$mapping->delete();
+            $second->deleteFromStage('Live');
+            $second->deleteFromStage('Stage');
+            $mapping->delete();
 
-			// Determine whether the fallback is matched.
+            // Determine whether the fallback is matched.
 
-			$response = $this->get('wrong/page');
-			$this->assertEquals($response->getStatusCode(), 303);
-			$this->assertEquals($response->getHeader('Location'), '/wrong/?misdirected=1');
-		}
-		else {
+            $response = $this->get('wrong/page');
+            $this->assertEquals($response->getStatusCode(), 303);
+            $this->assertEquals($response->getHeader('Location'), '/wrong/?misdirected=1');
+        } else {
 
-			// The database needs to be cleaned up to prevent further testing conflict.
+            // The database needs to be cleaned up to prevent further testing conflict.
 
-			$mapping->delete();
-		}
+            $mapping->delete();
+        }
 
-		// Instantiate a director rule to use.
+        // Instantiate a director rule to use.
 
-		Config::modify()->set(Director::class, 'rules', array(
-			'wrong/page' => Controller::class
-		));
+        Config::modify()->set(Director::class, 'rules', [
+            'wrong/page' => Controller::class
+        ]);
 
-		// Determine whether the director rule is matched.
+        // Determine whether the director rule is matched.
 
-		$response = $this->get('wrong/page');
-		$this->assertEquals($response->getStatusCode(), 200);
-		$this->assertEquals($response->getHeader('Location'), null);
-	}
+        $response = $this->get('wrong/page');
+        $this->assertEquals($response->getStatusCode(), 200);
+        $this->assertEquals($response->getHeader('Location'), null);
+    }
 
 }

--- a/tests/UnitTests.php
+++ b/tests/UnitTests.php
@@ -15,196 +15,201 @@ use Symbiote\Multisites\Multisites;
  *	@author Nathan Glasl <nathan@symbiote.com.au>
  */
 
-class UnitTests extends SapphireTest {
+class UnitTests extends SapphireTest
+{
 
-	protected $usesDatabase = true;
+    protected $usesDatabase = true;
 
-	/**
-	 *	The test to ensure the simple link mappings are functioning correctly.
-	 */
+    /**
+     *	The test to ensure the simple link mappings are functioning correctly.
+     */
 
-	public function testSimpleLinkMappings() {
+    public function testSimpleLinkMappings()
+    {
 
-		// Instantiate link mappings to use (the equivalent of does NOT include hostname).
+        // Instantiate link mappings to use (the equivalent of does NOT include hostname).
 
-		$first = LinkMapping::create(
-			array(
-				'LinkType' => 'Simple',
-				'MappedLink' => 'wrong/page',
-				'RedirectLink' => 'pending'
-			)
-		);
-		$first->write();
-		LinkMapping::create(
-			array(
-				'LinkType' => 'Simple',
-				'MappedLink' => 'pending',
-				'RedirectLink' => 'correct/page'
-			)
-		)->write();
+        $first = LinkMapping::create(
+            [
+                'LinkType' => 'Simple',
+                'MappedLink' => 'wrong/page',
+                'RedirectLink' => 'pending'
+            ]
+        );
+        $first->write();
+        LinkMapping::create(
+            [
+                'LinkType' => 'Simple',
+                'MappedLink' => 'pending',
+                'RedirectLink' => 'correct/page'
+            ]
+        )->write();
 
-		// Instantiate a request to use.
+        // Instantiate a request to use.
 
-		$request = new HTTPRequest('GET', 'wrong/page');
+        $request = new HTTPRequest('GET', 'wrong/page');
 
-		// Determine whether the simple link mappings are functioning correctly.
+        // Determine whether the simple link mappings are functioning correctly.
 
-		$testing = true;
-		$service = singleton(MisdirectionService::class);
-		$chain = $service->getMappingByRequest($request, $testing);
-		$this->assertEquals(count($chain), 2);
-		$match = end($chain);
-		$this->assertEquals($match['LinkMapping']->getLink(), '/correct/page');
+        $testing = true;
+        $service = singleton(MisdirectionService::class);
+        $chain = $service->getMappingByRequest($request, $testing);
+        $this->assertEquals(count($chain), 2);
+        $match = end($chain);
+        $this->assertEquals($match['LinkMapping']->getLink(), '/correct/page');
 
-		// Update the link mapping and request (to the equivalent of includes hostname).
+        // Update the link mapping and request (to the equivalent of includes hostname).
 
-		$first->MappedLink = 'www.site.com/wrong/page';
-		$first->IncludesHostname = 1;
-		$first->write();
-		$request->addHeader('Host', 'www.site.com');
+        $first->MappedLink = 'www.site.com/wrong/page';
+        $first->IncludesHostname = 1;
+        $first->write();
+        $request->addHeader('Host', 'www.site.com');
 
-		// Determine whether the simple link mappings are functioning correctly.
+        // Determine whether the simple link mappings are functioning correctly.
 
-		$chain = $service->getMappingByRequest($request, $testing);
-		$this->assertEquals(count($chain), 2);
-		$match = end($chain);
-		$this->assertEquals($match['LinkMapping']->getLink(), '/correct/page');
-	}
+        $chain = $service->getMappingByRequest($request, $testing);
+        $this->assertEquals(count($chain), 2);
+        $match = end($chain);
+        $this->assertEquals($match['LinkMapping']->getLink(), '/correct/page');
+    }
 
-	/**
-	 *	The test to ensure the regular expression replacement is correct.
-	 */
+    /**
+     *	The test to ensure the regular expression replacement is correct.
+     */
 
-	public function testRegularExpressionReplacement() {
+    public function testRegularExpressionReplacement()
+    {
 
-		// Instantiate a link mapping to use.
+        // Instantiate a link mapping to use.
 
-		$mapping = LinkMapping::create(
-			array(
-				'LinkType' => 'Regular Expression',
-				'MappedLink' => '^www\.wrong\.com(/page)?/(index){1}\.php$',
-				'RedirectLink' => 'https://www.correct.com$1'
-			)
-		);
-		$mapping->setMatchedURL('www.wrong.com/page/index.php');
+        $mapping = LinkMapping::create(
+            [
+                'LinkType' => 'Regular Expression',
+                'MappedLink' => '^www\.wrong\.com(/page)?/(index){1}\.php$',
+                'RedirectLink' => 'https://www.correct.com$1'
+            ]
+        );
+        $mapping->setMatchedURL('www.wrong.com/page/index.php');
 
-		// Determine whether the regular expression replacement is correct.
+        // Determine whether the regular expression replacement is correct.
 
-		$this->assertEquals($mapping->getLink(), ClassInfo::exists(Multisites::class) ? 'https://www.correct.com/page?misdirected=1' : 'https://www.correct.com/page');
-	}
+        $this->assertEquals($mapping->getLink(), ClassInfo::exists(Multisites::class) ? 'https://www.correct.com/page?misdirected=1' : 'https://www.correct.com/page');
+    }
 
-	/**
-	 *	The test to ensure the regular expression link mappings are functioning correctly.
-	 */
+    /**
+     *	The test to ensure the regular expression link mappings are functioning correctly.
+     */
 
-	public function testRegularExpressionLinkMappings() {
+    public function testRegularExpressionLinkMappings()
+    {
 
-		// Instantiate link mappings to use (the equivalent of does NOT include hostname).
+        // Instantiate link mappings to use (the equivalent of does NOT include hostname).
 
-		$first = LinkMapping::create(
-			array(
-				'LinkType' => 'Regular Expression',
-				'MappedLink' => '^wrong(.*)$',
-				'RedirectLink' => 'pending\\1'
-			)
-		);
-		$first->write();
-		LinkMapping::create(
-			array(
-				'LinkType' => 'Regular Expression',
-				'MappedLink' => '^pending(.*)$',
-				'RedirectLink' => 'correct\\1'
-			)
-		)->write();
+        $first = LinkMapping::create(
+            [
+                'LinkType' => 'Regular Expression',
+                'MappedLink' => '^wrong(.*)$',
+                'RedirectLink' => 'pending\\1'
+            ]
+        );
+        $first->write();
+        LinkMapping::create(
+            [
+                'LinkType' => 'Regular Expression',
+                'MappedLink' => '^pending(.*)$',
+                'RedirectLink' => 'correct\\1'
+            ]
+        )->write();
 
-		// Instantiate a request to use.
+        // Instantiate a request to use.
 
-		$request = new HTTPRequest('GET', 'wrong/page');
+        $request = new HTTPRequest('GET', 'wrong/page');
 
-		// Determine whether the regular expression link mappings are functioning correctly.
+        // Determine whether the regular expression link mappings are functioning correctly.
 
-		$testing = true;
-		$service = singleton(MisdirectionService::class);
-		$chain = $service->getMappingByRequest($request, $testing);
-		$this->assertEquals(count($chain), 2);
-		$match = end($chain);
-		$this->assertEquals($match['LinkMapping']->getLink(), '/correct/page');
+        $testing = true;
+        $service = singleton(MisdirectionService::class);
+        $chain = $service->getMappingByRequest($request, $testing);
+        $this->assertEquals(count($chain), 2);
+        $match = end($chain);
+        $this->assertEquals($match['LinkMapping']->getLink(), '/correct/page');
 
-		// Update the link mapping and request (to the equivalent of includes hostname).
+        // Update the link mapping and request (to the equivalent of includes hostname).
 
-		$first->MappedLink = '^www\.site\.com/wrong(.*)$';
-		$first->IncludesHostname = 1;
-		$first->write();
-		$request->addHeader('Host', 'www.site.com');
+        $first->MappedLink = '^www\.site\.com/wrong(.*)$';
+        $first->IncludesHostname = 1;
+        $first->write();
+        $request->addHeader('Host', 'www.site.com');
 
-		// Determine whether the regular expression link mappings are functioning correctly.
+        // Determine whether the regular expression link mappings are functioning correctly.
 
-		$chain = $service->getMappingByRequest($request, $testing);
-		$this->assertEquals(count($chain), 2);
-		$match = end($chain);
-		$this->assertEquals($match['LinkMapping']->getLink(), '/correct/page');
-	}
+        $chain = $service->getMappingByRequest($request, $testing);
+        $this->assertEquals(count($chain), 2);
+        $match = end($chain);
+        $this->assertEquals($match['LinkMapping']->getLink(), '/correct/page');
+    }
 
-	/**
-	 *	The test to ensure the link mapping priority is correct.
-	 */
+    /**
+     *	The test to ensure the link mapping priority is correct.
+     */
 
-	public function testMappingPriority() {
+    public function testMappingPriority()
+    {
 
-		// Instantiate link mappings to use.
+        // Instantiate link mappings to use.
 
-		$first = LinkMapping::create(
-			array(
-				'LinkType' => 'Simple',
-				'MappedLink' => 'wrong/page',
-				'Priority' => 1
-			)
-		);
-		$first->write();
-		$second = LinkMapping::create(
-			array(
-				'LinkType' => 'Simple',
-				'MappedLink' => 'wrong/page',
-				'Priority' => 1
-			)
-		);
-		$second->write();
+        $first = LinkMapping::create(
+            [
+                'LinkType' => 'Simple',
+                'MappedLink' => 'wrong/page',
+                'Priority' => 1
+            ]
+        );
+        $first->write();
+        $second = LinkMapping::create(
+            [
+                'LinkType' => 'Simple',
+                'MappedLink' => 'wrong/page',
+                'Priority' => 1
+            ]
+        );
+        $second->write();
 
-		// Instantiate a request to use.
+        // Instantiate a request to use.
 
-		$request = new HTTPRequest('GET', 'wrong/page');
+        $request = new HTTPRequest('GET', 'wrong/page');
 
-		// Determine whether the link mapping first created is matched.
+        // Determine whether the link mapping first created is matched.
 
-		$testing = true;
-		$service = singleton(MisdirectionService::class);
-		$chain = $service->getMappingByRequest($request, $testing);
-		$this->assertEquals(count($chain), 1);
-		$match = end($chain);
-		$this->assertEquals($match['LinkMapping']->ID, $first->ID);
+        $testing = true;
+        $service = singleton(MisdirectionService::class);
+        $chain = $service->getMappingByRequest($request, $testing);
+        $this->assertEquals(count($chain), 1);
+        $match = end($chain);
+        $this->assertEquals($match['LinkMapping']->ID, $first->ID);
 
-		// Update the default link mapping priority.
+        // Update the default link mapping priority.
 
-		Config::modify()->set(LinkMapping::class, 'priority', 'DESC');
+        Config::modify()->set(LinkMapping::class, 'priority', 'DESC');
 
-		// Determine whether the link mapping most recently created is matched.
+        // Determine whether the link mapping most recently created is matched.
 
-		$chain = $service->getMappingByRequest($request, $testing);
-		$this->assertEquals(count($chain), 1);
-		$match = end($chain);
-		$this->assertEquals($match['LinkMapping']->ID, $second->ID);
+        $chain = $service->getMappingByRequest($request, $testing);
+        $this->assertEquals(count($chain), 1);
+        $match = end($chain);
+        $this->assertEquals($match['LinkMapping']->ID, $second->ID);
 
-		// Update the link mapping priority.
+        // Update the link mapping priority.
 
-		$first->Priority = 2;
-		$first->write();
+        $first->Priority = 2;
+        $first->write();
 
-		// Determine whether the link mapping first created is matched.
+        // Determine whether the link mapping first created is matched.
 
-		$chain = $service->getMappingByRequest($request, $testing);
-		$this->assertEquals(count($chain), 1);
-		$match = end($chain);
-		$this->assertEquals($match['LinkMapping']->ID, $first->ID);
-	}
+        $chain = $service->getMappingByRequest($request, $testing);
+        $this->assertEquals(count($chain), 1);
+        $match = end($chain);
+        $this->assertEquals($match['LinkMapping']->ID, $first->ID);
+    }
 
 }


### PR DESCRIPTION
This change is the result of running `php-cs-fixer fix` using the provided .php-cs-fixer.dist.php file to fix inconsistent indenting, and move arrays to short array notation.

Add w=1 to the URL in github to view a less noisy diff without whitespace changes.
